### PR TITLE
seeders: Seed bases/turnos to full-perms role

### DIFF
--- a/database/seeders/Security/RolSeeder.php
+++ b/database/seeders/Security/RolSeeder.php
@@ -2,6 +2,8 @@
 
 namespace Database\Seeders\Security;
 
+use Cat\Models\Base;
+use Cat\Models\Turno;
 use Cat\Modules\Security\Models\Permission;
 use Cat\Modules\Security\Models\Role;
 use Illuminate\Database\Seeder;
@@ -10,11 +12,14 @@ class RolSeeder extends Seeder
 {
     public function run()
     {
+        /** @var Role $rol */
         $rol = Role::create([
             'name' => 'Permisos full',
         ]);
         
         $rol->syncPermissions(Permission::all());
+        $rol->bases()->saveMany(Base::all());
+        $rol->turnos()->saveMany(Turno::all());
     }
     
 }

--- a/database/seeders/Security/UsersTableSeeder.php
+++ b/database/seeders/Security/UsersTableSeeder.php
@@ -20,7 +20,7 @@ class UsersTableSeeder extends Seeder
         $user = User::create([
             'name'           => $faker->name(),
             'cuit'           => '20' . $faker->unique()->numerify('########') . '0',
-            'email'          => $faker->unique()->safeEmail(),
+            'email'          => 'dev@company.com',
             'password'       => bcrypt('password'),
             'remember_token' => \Illuminate\Support\Str::random(10),
         ]);


### PR DESCRIPTION
Assign all bases and turnos to the 'Permisos full' role in RolSeeder so seeded users have access to all work locations and shifts.

Also pin the dev user email to a fixed address for predictable local/test logins.